### PR TITLE
Toml parsing module is implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist-newstyle
 *.ps
 *.eventlog
 *.eventlog.html
+config.toml
 
 .env
 

--- a/registrar.cabal
+++ b/registrar.cabal
@@ -28,6 +28,7 @@ library
     Registrar.Bot.Types
     Registrar.Bot.Webhook
     Registrar.ClientTypes
+    Registrar.Config
     Registrar.Database
     Registrar.Database.Community
     Registrar.Database.Migrations
@@ -48,12 +49,14 @@ library
     , containers
     , cryptohash-sha256
     , esqueleto
+    , file-embed
     , generic-lens
     , hashable
     , http-media
     , http-types
     , lens
     , log-base
+    , markdown-unlit
     , monad-logger
     , mtl
     , openapi3
@@ -61,6 +64,7 @@ library
     , persistent
     , persistent-migration
     , persistent-postgresql
+    , raw-strings-qq
     , resource-pool
     , safe-exceptions
     , servant
@@ -74,6 +78,7 @@ library
     , telegram-bot-simple
     , text
     , time
+    , toml-parser
     , transformers
     , unicode-show
     , unliftio

--- a/registrar.cabal
+++ b/registrar.cabal
@@ -49,14 +49,12 @@ library
     , containers
     , cryptohash-sha256
     , esqueleto
-    , file-embed
     , generic-lens
     , hashable
     , http-media
     , http-types
     , lens
     , log-base
-    , markdown-unlit
     , monad-logger
     , mtl
     , openapi3
@@ -64,7 +62,6 @@ library
     , persistent
     , persistent-migration
     , persistent-postgresql
-    , raw-strings-qq
     , resource-pool
     , safe-exceptions
     , servant

--- a/src/Registrar.hs
+++ b/src/Registrar.hs
@@ -25,6 +25,7 @@ data Options w = Options
   , migrations :: !(w ::: Bool <?> "Run migrations" <!> "False" <#> "m")
   , datasetFolder :: !(w ::: FilePath <?> "Default dataset folder" <#> "f")
   , botToken :: !(w ::: String <?> "Telegram bot token" <#> "t")
+  , filePath :: !(w ::: String <?> "Config file path" <#> "f")
   }
   deriving stock (Generic)
 

--- a/src/Registrar.hs
+++ b/src/Registrar.hs
@@ -38,11 +38,6 @@ runApp :: IO ()
 runApp = do
   (op :: Options Unwrapped) <- unwrapRecord "Registrar application"
 
-  configResult <- loadConfig op.filePath
-  case configResult of
-    Success _ cfg -> print cfg
-    Failure errs -> putStrLn "Failed to load config"
-
   pool <- runNoLoggingT $ createPostgresqlPool op.database op.databasePoolSize
   let ?pool = pool
   migrateDb

--- a/src/Registrar.hs
+++ b/src/Registrar.hs
@@ -27,7 +27,7 @@ data Options w = Options
   , migrations :: !(w ::: Bool <?> "Run migrations" <!> "False" <#> "m")
   , datasetFolder :: !(w ::: FilePath <?> "Default dataset folder" <#> "f")
   , botToken :: !(w ::: String <?> "Telegram bot token" <#> "t")
-  , filePath :: !(w ::: String <?> "Config file path" <#> "c")
+  , config :: !(w ::: String <?> "Config file path" <#> "c")
   }
   deriving stock (Generic)
 

--- a/src/Registrar/Config.hs
+++ b/src/Registrar/Config.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Registrar.Config where
+
+import Data.FileEmbed (embedFile)
+import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8)
+import GHC.Generics (Generic)
+import Text.RawString.QQ (r)
+import Toml qualified
+import Toml.Schema (FromValue, ToTable, ToValue)
+import Toml.Schema.Generic (GenericTomlTable (..))
+import Toml.Schema.Matcher (Result)
+
+data AppConfig = AppConfig
+  { port :: Int
+  , database :: Text
+  , databasePoolSize :: Int
+  , migrations :: Bool
+  , datasetFolder :: Text
+  , botSettings :: BotSettings
+  }
+  deriving (Eq, Show, Generic)
+  deriving (ToTable, ToValue, FromValue) via GenericTomlTable AppConfig
+
+data BotSettings = BotSettings
+  { botToken :: Text
+  , botName :: Text
+  , debugEnabled :: Bool
+  , warnSetting :: WarnSetting
+  }
+  deriving (Eq, Show, Generic)
+  deriving (ToTable, ToValue, FromValue) via GenericTomlTable BotSettings
+
+data WarnSetting = WarnSetting
+  { userWarningInterval :: Int
+  , userWarnLimit :: Int
+  , permanentBanDuration :: Int
+  }
+  deriving (Eq, Show, Generic)
+  deriving (ToTable, ToValue, FromValue) via GenericTomlTable WarnSetting
+
+configStr :: Text
+configStr = decodeUtf8 $(embedFile "config.toml")
+
+loadConfig :: Result String AppConfig
+loadConfig = Toml.decode configStr

--- a/src/Registrar/Config.hs
+++ b/src/Registrar/Config.hs
@@ -7,6 +7,7 @@
 
 module Registrar.Config where
 
+import Data.ByteString qualified as BS
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8)
 import GHC.Generics (Generic)
@@ -43,5 +44,5 @@ data WarnSetting = WarnSetting
   deriving (Eq, Show, Generic)
   deriving (ToTable, ToValue, FromValue) via GenericTomlTable WarnSetting
 
-loadConfig :: Result String AppConfig
-loadConfig = Toml.decode' $ decodeUtf8 . "config.toml"
+loadConfig :: FilePath -> IO (Result Toml.DecodeError AppConfig)
+loadConfig filepath = Toml.decode' . decodeUtf8 <$> BS.readFile filepath

--- a/src/Registrar/Config.hs
+++ b/src/Registrar/Config.hs
@@ -7,11 +7,9 @@
 
 module Registrar.Config where
 
-import Data.FileEmbed (embedFile)
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8)
 import GHC.Generics (Generic)
-import Text.RawString.QQ (r)
 import Toml qualified
 import Toml.Schema (FromValue, ToTable, ToValue)
 import Toml.Schema.Generic (GenericTomlTable (..))
@@ -45,8 +43,5 @@ data WarnSetting = WarnSetting
   deriving (Eq, Show, Generic)
   deriving (ToTable, ToValue, FromValue) via GenericTomlTable WarnSetting
 
-configStr :: Text
-configStr = decodeUtf8 $(embedFile "config.toml")
-
 loadConfig :: Result String AppConfig
-loadConfig = Toml.decode configStr
+loadConfig = Toml.decode' $ decodeUtf8 . "config.toml"


### PR DESCRIPTION
# Load Application Configuration from TOML File

## Changes

Added support for loading application settings from a `config.toml` file instead of relying solely on command-line options and environment variables.

## Implementation

- Added `toml-parser` dependency for parsing TOML configuration files
- Configurations now support:
  - General application options (port, database connection, pool size, migrations, dataset folder)
  - Bot settings (token, name, debug mode)
  - Warning settings (intervals, limits, ban duration)

## Motivation

As environment variables and settings grew, managing them became cumbersome. This change consolidates all configuration into a single `config.toml` file for better maintainability.

Resolves #45 